### PR TITLE
Fix three codebase bugs

### DIFF
--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,10 @@
+import { PrismaClient } from "@prisma/client";
+const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
+
+export const prisma =
+  globalForPrisma.prisma ||
+  new PrismaClient({
+    log: ["query", "info", "warn", "error"],
+  });
+
+if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;

--- a/src/pages/api/spanish.ts
+++ b/src/pages/api/spanish.ts
@@ -4,7 +4,7 @@ import { generateObject } from "ai";
 import { z } from "zod";
 import Langfuse from "langfuse";
 import APIKeyManager from "@/util/apiKeyManager";
-import { PrismaClient } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
 
 // This route must be rendered on the server (SSR) to handle dynamic requests.
 export const prerender = false;
@@ -18,9 +18,6 @@ const langfuse = new Langfuse({
 
 // Initialize API key manager
 const apiKeyManager = APIKeyManager.getInstance();
-
-// Initialize Prisma client
-const prisma = new PrismaClient();
 
 export enum ConjugationTense {
   Preterite = "Preterite",

--- a/src/pages/api/spanish/[id].ts
+++ b/src/pages/api/spanish/[id].ts
@@ -1,7 +1,5 @@
-import { PrismaClient } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
 import type { APIRoute } from "astro";
-
-const prisma = new PrismaClient();
 
 export const GET: APIRoute = async ({ params, request }) => {
   try {

--- a/src/pages/api/spanish/generateNew.ts
+++ b/src/pages/api/spanish/generateNew.ts
@@ -1,7 +1,5 @@
-import { PrismaClient } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
 import type { APIRoute } from "astro";
-
-const prisma = new PrismaClient();
 
 export const POST: APIRoute = async ({ params, request }) => {
   try {

--- a/src/pages/api/spanish/getList.ts
+++ b/src/pages/api/spanish/getList.ts
@@ -1,7 +1,5 @@
-import { PrismaClient } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
 import type { APIRoute } from "astro";
-
-const prisma = new PrismaClient();
 
 export const GET: APIRoute = async ({ params, request }) => {
   try {

--- a/src/pages/api/submitAPIKey.ts
+++ b/src/pages/api/submitAPIKey.ts
@@ -5,6 +5,7 @@ import { createCerebras } from '@ai-sdk/cerebras';
 import pkg from '@prisma/client';
 const { PrismaClient } = pkg;
 import APIKeyManager from "@/util/apiKeyManager";
+import { prisma } from "@/lib/prisma";
 
 export const prerender = false;
 
@@ -13,7 +14,6 @@ export interface APIKeySubmission {
     service: "gemini" | "cerebras";
 }
 
-const prisma = new PrismaClient();
 const apiKeyManager = APIKeyManager.getInstance();
 
 export async function POST(request: APIContext) {
@@ -31,7 +31,7 @@ export async function POST(request: APIContext) {
         if (service === "gemini") {
             try {
                 // Use the API key manager's add method which includes validation
-                const success = await apiKeyManager.addKey(apiKey);
+                const success = await apiKeyManager.addKey(apiKey, "GEMINI");
                 
                 if (!success) {
                     return new Response(JSON.stringify({ error: "Invalid Gemini API key" }), {

--- a/src/pages/api/test-spanish.ts
+++ b/src/pages/api/test-spanish.ts
@@ -1,7 +1,5 @@
 import type { APIRoute } from "astro";
-import { PrismaClient } from "@prisma/client";
-
-const prisma = new PrismaClient();
+import { prisma } from "@/lib/prisma";
 
 export const GET: APIRoute = async ({ request }) => {
   const testResults = {

--- a/src/util/apiKeyManager.ts
+++ b/src/util/apiKeyManager.ts
@@ -1,10 +1,7 @@
-import pkg from "@prisma/client";
-const { PrismaClient } = pkg;
+import { prisma } from "@/lib/prisma";
 import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import { streamText } from "ai";
 import { createCerebras } from "@ai-sdk/cerebras";
-
-const prisma = new PrismaClient();
 
 interface APIKeyInfo {
   id: string;


### PR DESCRIPTION
Fix PrismaClient connection exhaustion by implementing a singleton pattern and correct API key validation logic in `submitAPIKey.ts`.

The `PrismaClient` was being instantiated multiple times across various API routes, which can lead to connection pool exhaustion and performance issues. This PR introduces a singleton pattern for `PrismaClient` to ensure a single, reusable instance.

Additionally, the `apiKeyManager.addKey` call in `submitAPIKey.ts` for Gemini keys was missing the required type argument, leading to incorrect validation and storage. This has been corrected to pass the `"GEMINI"` type.

---

[Open in Web](https://www.cursor.com/agents%3Fid=bc-c45b8bc1-8a40-48e3-9e0b-20f53188df3c) • [Open in Cursor](https://cursor.com/background-agent%3FbcId=bc-c45b8bc1-8a40-48e3-9e0b-20f53188df3c)